### PR TITLE
Replace `stdenv.lib` with `lib` in `dbcritic.nix`

### DIFF
--- a/dbcritic.nix
+++ b/dbcritic.nix
@@ -1,8 +1,8 @@
-{ stdenv, idris, postgresql }:
+{ stdenv, lib, idris, postgresql }:
 stdenv.mkDerivation {
     name = "dbcritic";
 
-    src = stdenv.lib.cleanSource ./.;
+    src = lib.cleanSource ./.;
     buildInputs = [ idris postgresql ];
 
     phases = [ "unpackPhase" "buildPhase"


### PR DESCRIPTION
`stdenv.lib` is deprecated in newer versions of nixpkgs.

Tested with `nix build --no-link`. This leads to a different derivation, but that's because `dbcritic.nix` is part of the `src` of the derivation.