### PR TITLE
Add check to disable 32 bits primary keys

### DIFF
--- a/Dbcritic/Check/PrimaryKeyBigint.idr
+++ b/Dbcritic/Check/PrimaryKeyBigint.idr
@@ -1,0 +1,48 @@
+module Dbcritic.Check.PrimaryKeyType
+
+import Control.IOExcept
+import Dbcritic.Check
+import Dbcritic.Libpq
+
+mkIssue : String -> String -> Issue
+mkIssue table column =
+    let
+        identifier  = [ table, column ]
+        description = "The table ‘" ++ table ++ "’ primary key (" ++ column ++ ") is "
+                      ++ "of type ‘integer’ instead of ‘bigint’."
+        problems    = [ "PostgreSQL's integer type is 4 bytes. It is relatively easy to run out of values." ]
+        solutions   = [ "Change the type of ‘" ++ table ++ "." ++ column ++ "’ to ‘bigint’, "
+                      ++ "as well as its associated auto generating sequence if it exists." ]
+    in
+        MkIssue identifier description problems solutions IsNonEmpty IsNonEmpty IsNonEmpty
+
+export
+checkPrimaryKeyBigint : Check
+checkPrimaryKeyBigint = MkCheck name help inspect
+    where
+    name = "primary_key_bigint"
+    help = "Check that there are no tables with an integer primary key."
+
+    inspectRow : List (Maybe String) -> IOExcept String Issue
+    inspectRow [Just table, Just column] = pure (mkIssue table column)
+    inspectRow _ = ioe_fail "checkPrimaryKeyBigint: Bad result"
+
+    inspect : PgConnection -> IOExcept String (List Issue)
+    inspect conn = do
+        res <- pgExecute conn """
+            SELECT
+                kcu.table_name as table_name,
+                kcu.column_name as column_name
+            FROM information_schema.table_constraints tco
+            JOIN information_schema.key_column_usage kcu
+                ON kcu.constraint_name = tco.constraint_name
+                AND kcu.constraint_schema = tco.constraint_schema
+                AND kcu.constraint_name = tco.constraint_name
+            JOIN information_schema.columns c
+                ON c.table_name = kcu.table_name
+                AND c.column_name = kcu.column_name
+            WHERE tco.constraint_type = 'PRIMARY KEY'
+            AND c.data_type = 'integer'
+            ORDER BY table_name
+        """
+        traverse inspectRow (pgGrid res)

--- a/Dbcritic/Check/PrimaryKeyBigint.idr
+++ b/Dbcritic/Check/PrimaryKeyBigint.idr
@@ -19,15 +19,15 @@ formatTypeByteSize type =
 mkIssue : String -> String -> String -> String -> Issue
 mkIssue schema table column column_type =
     let
-        fullTable   = schema ++ "." ++ table
-        identifier  = [ schema, table, column ]
-        description = "The table ‘" ++ fullTable ++ "’ primary key (" ++ column ++ ") is "
-                      ++ "of type ‘" ++ column_type ++ "’ instead of ‘bigint’."
+        fullTable      = schema ++ "." ++ table
+        identifier     = [ schema, table, column ]
+        description    = "The table ‘" ++ fullTable ++ "’ primary key (" ++ column ++ ") is "
+                         ++ "of type ‘" ++ column_type ++ "’ instead of ‘bigint’."
         columnByteSize = formatTypeByteSize column_type
-        problems    = [ "PostgreSQL's " ++ column_type ++ " type is " ++ columnByteSize
-                      ++ " bytes. It is relatively easy to run out of values." ]
-        solutions   = [ "Change the type of ‘" ++ fullTable ++ "." ++ column ++ "’ to ‘bigint’, "
-                      ++ "as well as its associated auto generating sequence if it exists." ]
+        problems       = [ "PostgreSQL's " ++ column_type ++ " type is " ++ columnByteSize
+                         ++ " bytes. It is relatively easy to run out of values." ]
+        solutions      = [ "Change the type of ‘" ++ fullTable ++ "." ++ column ++ "’ to ‘bigint’, "
+                         ++ "as well as its associated auto generating sequence if it exists." ]
     in
         MkIssue identifier description problems solutions IsNonEmpty IsNonEmpty IsNonEmpty
 

--- a/Dbcritic/Check/PrimaryKeyBigint.idr
+++ b/Dbcritic/Check/PrimaryKeyBigint.idr
@@ -1,4 +1,4 @@
-module Dbcritic.Check.PrimaryKeyType
+module Dbcritic.Check.PrimaryKeyBigint
 
 import Control.IOExcept
 import Dbcritic.Check
@@ -17,14 +17,14 @@ formatTypeByteSize type =
         byteSizeOfType _ = Nothing
 
 mkIssue : String -> String -> String -> String -> Issue
-mkIssue schema table column column_type =
+mkIssue schema table column columnType =
     let
         fullTable      = schema ++ "." ++ table
         identifier     = [ schema, table, column ]
         description    = "The table ‘" ++ fullTable ++ "’ primary key (" ++ column ++ ") is "
-                         ++ "of type ‘" ++ column_type ++ "’ instead of ‘bigint’."
-        columnByteSize = formatTypeByteSize column_type
-        problems       = [ "PostgreSQL's " ++ column_type ++ " type is " ++ columnByteSize
+                         ++ "of type ‘" ++ columnType ++ "’ instead of ‘bigint’."
+        columnByteSize = formatTypeByteSize columnType
+        problems       = [ "PostgreSQL's " ++ columnType ++ " type is " ++ columnByteSize
                          ++ " bytes. It is relatively easy to run out of values." ]
         solutions      = [ "Change the type of ‘" ++ fullTable ++ "." ++ column ++ "’ to ‘bigint’, "
                          ++ "as well as its associated auto generating sequence if it exists." ]
@@ -36,11 +36,11 @@ checkPrimaryKeyBigint : Check
 checkPrimaryKeyBigint = MkCheck name help inspect
     where
     name = "primary_key_bigint"
-    help = "Check that there are no tables with an integer primary key."
+    help = "Check that there are no tables with a smallint or integer primary key."
 
     inspectRow : List (Maybe String) -> IOExcept String Issue
-    inspectRow [Just schema, Just table, Just column, Just column_type] =
-                   pure (mkIssue schema table column column_type)
+    inspectRow [Just schema, Just table, Just column, Just columnType] =
+                   pure (mkIssue schema table column columnType)
     inspectRow _ = ioe_fail "checkPrimaryKeyBigint: Bad result"
 
     inspect : PgConnection -> IOExcept String (List Issue)

--- a/Main.idr
+++ b/Main.idr
@@ -5,6 +5,7 @@ import Data.IORef
 import Dbcritic.Check
 import Dbcritic.Check.IndexFkRef
 import Dbcritic.Check.PrimaryKey
+import Dbcritic.Check.PrimaryKeyBigint
 import Dbcritic.Check.TimeZone
 import Dbcritic.Check.Timestamptz
 import Dbcritic.Config
@@ -12,7 +13,7 @@ import Dbcritic.Libpq
 import System
 
 checks : List Check
-checks = [ checkIndexFkRef, checkPrimaryKey, checkTimeZone, checkTimestamptz ]
+checks = [ checkIndexFkRef, checkPrimaryKey, checkPrimaryKeyBigint, checkTimeZone, checkTimestamptz ]
 
 main' : IOExcept String Int
 main' = do

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Issues may result from the cluster configuration or from the database schema.
 
 dbcritic implements the following checks:
 
-| Check               | Description                                                                   |
-| ------------------- | ----------------------------------------------------------------------------- |
-| index_fk_ref        | Check that foreign key has an index on the referencing side.                  |
-| primary_key         | Check that each table has a primary key constraint.                           |
-| primary_key_bigint  | Check that integer primary keys are of type bigint.                           |
-| timestamptz         | Check that columns are of type ‘timestamptz’ rather than of type ‘timestamp’. |
-| time_zone           | Check that the ‘TimeZone’ parameter is set to a sensible value.               |
+| Check              | Description                                                                   |
+| -------------------| ----------------------------------------------------------------------------- |
+| index_fk_ref       | Check that foreign key has an index on the referencing side.                  |
+| primary_key        | Check that each table has a primary key constraint.                           |
+| primary_key_bigint | Check that integer primary keys are of type bigint.                           |
+| timestamptz        | Check that columns are of type ‘timestamptz’ rather than of type ‘timestamp’. |
+| time_zone          | Check that the ‘TimeZone’ parameter is set to a sensible value.               |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ Issues may result from the cluster configuration or from the database schema.
 
 dbcritic implements the following checks:
 
-| Check        | Description                                                                   |
-| ------------ | ----------------------------------------------------------------------------- |
-| index_fk_ref | Check that foreign key has an index on the referencing side.                  |
-| primary_key  | Check that each table has a primary key constraint.                           |
-| timestamptz  | Check that columns are of type ‘timestamptz’ rather than of type ‘timestamp’. |
-| time_zone    | Check that the ‘TimeZone’ parameter is set to a sensible value.               |
+| Check               | Description                                                                   |
+| ------------------- | ----------------------------------------------------------------------------- |
+| index_fk_ref        | Check that foreign key has an index on the referencing side.                  |
+| primary_key         | Check that each table has a primary key constraint.                           |
+| primary_key_bigint  | Check that integer primary keys are of type bigint.                           |
+| timestamptz         | Check that columns are of type ‘timestamptz’ rather than of type ‘timestamp’. |
+| time_zone           | Check that the ‘TimeZone’ parameter is set to a sensible value.               |
 
 ## Configuration
 


### PR DESCRIPTION
Fixes https://github.com/channable/dbcritic/issues/6

Primary keys of type `integer` or `smallint` are disabled in favor of `bigint`