### PR TITLE
ci: Update MacOS container to 12.6

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -51,7 +51,7 @@ blocks:
       agent:
         machine:
           type: "a1-standard-4"
-          os_image: "macos-xcode12"
+          os_image: "macos-xcode14"
 
       jobs:
         - name: "Build Dbcritic for macOS"


### PR DESCRIPTION
This is required as Semaphore is sunsetting its 11.5 image.