### PR TITLE
Update nixpkgs pin and add haskell overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /result
 *.ibc
 /dbcritic-bin
+.idea

--- a/nix/haskell-overlay.nix
+++ b/nix/haskell-overlay.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+self: super:
+
+{
+  # cheapskate is marked broken in nixpkgs.
+  cheapskate = with pkgs.haskell.lib;
+    markUnbroken (doJailbreak super.cheapskate);
+}

--- a/nix/nixpkgs-pinned.nix
+++ b/nix/nixpkgs-pinned.nix
@@ -1,1 +1,31 @@
-import (import ./sources.nix).nixpkgs
+# Provide almost the same arguments as the actual nixpkgs.
+# This allows us to further configure this nixpkgs instantiation in places where we need it.
+# In particular, `stack` needs this to be a function.
+{ overlays ? [] # additional overlays
+, config ? {} # Imported configuration
+, use_overlays ? true # Option to disable overlays, to get packages from purely nixpkgs
+}:
+# Provides our instantiation of nixpkgs with all overlays and extra tooling
+# that we pull in from other repositories.
+# This expression is what all places where we need a concrete instantiation of nixpkgs should use.
+let
+  sources = import ./sources.nix;
+
+  # Use no overlays when disabled. This way it is possible to use e.g. Cachix from nixpkgs, without
+  # it being affected by overlays.
+  used_overlays = if use_overlays then
+      [
+        (import ./overlay.nix)
+      ] ++ overlays
+    else
+      [];
+
+  nixpkgs = import sources.nixpkgs {
+    overlays = used_overlays;
+    config = {
+      imports = [ config ];
+      allowUnfree = true;
+    };
+  };
+in
+  nixpkgs

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,13 @@
+self: super:
+let
+  sources = import ./sources.nix;
+  haskellOverlay = import ./haskell-overlay.nix {
+    pkgs = self;
+  };
+in
+{
+  sources = if super ? sources then super.sources // sources else sources;
+  # Generic haskellPackages since neither Idris nor its dependencies
+  # are pinned to a specific GHC version.
+  haskellPackages = super.haskellPackages.extend haskellOverlay;
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-21.05",
+        "branch": "nixos-unstable",
         "description": "Nix Packages collection",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "55e93ae9eb9a26c3fd2505b3c33b42abb43f2e6d",
-        "sha256": "1j03z9yqch5jp2w7gs6a6hikklyiwlkp0bxqxqhmmghljz866xkx",
+        "rev": "970a59bd19eff3752ce552935687100c46e820a5",
+        "sha256": "sha256:06binyx1cv10nhw1riana0b5r38754p2qpffaijkax2yx4r3cx09",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/55e93ae9eb9a26c3fd2505b3c33b42abb43f2e6d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/970a59bd19eff3752ce552935687100c46e820a5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This updates the nixpkgs pin from `release-21.05` to a recent commit on the `nixpkgs-unstable` branch to update the nix dependencies. This subsequently introduces the problem that a package called `cheapskate` is [marked broken](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/haskell-modules/hackage-packages.nix) in nixpkgs. 

Therefore, this PR also adds a haskell overlay to mark this package as unbroken as workaround.