### PR TITLE
Remove macOS build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -66,12 +66,6 @@ blocks:
       jobs:
         - name: "Build Dbcritic for macOS"
           commands:
-            # Nix-based build:
-            - "sh ./install-nix --darwin-use-unencrypted-nix-store-volume"
-            - ". $HOME/.nix-profile/etc/profile.d/nix.sh"
-
-            - "nix build --print-build-logs --no-link"
-
             # Regular build with global libraries via Brew:
             - "brew install libpq idris"
             # Tell Idris where libpq is


### PR DESCRIPTION
The macOS build is broken and hard to maintain with little gained benefit.
For more background information, see: https://github.com/channable/dbcritic/pull/10