### PR TITLE
Set up a proper Nix environment with a nixpkgs overlay and development shell

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -50,7 +50,7 @@ blocks:
             - "sh ./install-nix --no-daemon"
             - ". $HOME/.nix-profile/etc/profile.d/nix.sh"
 
-            - "nix build --print-build-logs --no-link"
+            - "nix build -f release.nix --print-build-logs --no-link"
 
             - "cache store linux-nix-store-$(date -u -Idate) /nix"
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dbcritic can be build with Nix or without Nix.
 To build it with Nix, simply invoke nix-build:
 
 ```console
-$ nix-build
+$ nix-build release.nix
 ```
 
 This command will make a symlink `result` in the current directory.

--- a/dbcritic.nix
+++ b/dbcritic.nix
@@ -1,29 +1,25 @@
 { stdenv, lib, idris, postgresql }:
 stdenv.mkDerivation {
-    name = "dbcritic";
+  name = "dbcritic";
 
-    # Remove files that don't affect the final build.
-    # Keep only:
-    #  - The Makefile
-    #  - Any file ending in `.idr`
-    #  - The directories containing source (i.e. not `.git`, `.semaphore` and `nix`)
-    src = lib.cleanSourceWith {
-      src = ./.;
-      filter = path: _type:
-        lib.strings.hasSuffix "Makefile" path
-        || lib.strings.hasSuffix ".idr" path
-        || (
-          lib.pathIsDirectory path
-          && !builtins.elem (baseNameOf path) ["nix" ".semaphore" ".git"]
-        );
-    };
+  # Remove files that don't affect the final build.
+  # Keep only:
+  #  - The Makefile
+  #  - Any file ending in `.idr`
+  #  - The directories containing source (i.e. not `.git`, `.semaphore` and `nix`)
+  src = lib.cleanSourceWith {
+    src = ./.;
+    filter = path: _type:
+      lib.strings.hasSuffix "Makefile" path || lib.strings.hasSuffix ".idr" path
+      || (lib.pathIsDirectory path
+        && !builtins.elem (baseNameOf path) [ "nix" ".semaphore" ".git" ]);
+  };
 
-    buildInputs = [ idris postgresql ];
+  buildInputs = [ idris postgresql ];
 
-    phases = [ "unpackPhase" "buildPhase"
-               "installPhase" "fixupPhase" ];
-    installPhase = ''
-        mkdir --parents "$out/bin"
-        mv dbcritic-bin "$out/bin/dbcritic"
-    '';
+  phases = [ "unpackPhase" "buildPhase" "installPhase" "fixupPhase" ];
+  installPhase = ''
+    mkdir --parents "$out/bin"
+    mv dbcritic-bin "$out/bin/dbcritic"
+  '';
 }

--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,3 @@
-{ pkgs ? import nix/nixpkgs-pinned.nix {} }:
-pkgs.callPackage ./dbcritic.nix {}
+{ pkgs ? import nix/nixpkgs-pinned.nix { } }:
+
+pkgs.mkShell { inputsFrom = with pkgs; [ dbcritic ]; }

--- a/nix/nixpkgs-pinned.nix
+++ b/nix/nixpkgs-pinned.nix
@@ -1,9 +1,10 @@
 # Provide almost the same arguments as the actual nixpkgs.
 # This allows us to further configure this nixpkgs instantiation in places where we need it.
 # In particular, `stack` needs this to be a function.
-{ overlays ? [] # additional overlays
-, config ? {} # Imported configuration
-, use_overlays ? true # Option to disable overlays, to get packages from purely nixpkgs
+{ overlays ? [ ] # additional overlays
+, config ? { } # Imported configuration
+, use_overlays ?
+  true # Option to disable overlays, to get packages from purely nixpkgs
 }:
 # Provides our instantiation of nixpkgs with all overlays and extra tooling
 # that we pull in from other repositories.
@@ -13,12 +14,8 @@ let
 
   # Use no overlays when disabled. This way it is possible to use e.g. Cachix from nixpkgs, without
   # it being affected by overlays.
-  used_overlays = if use_overlays then
-      [
-        (import ./overlay.nix)
-      ] ++ overlays
-    else
-      [];
+  used_overlays =
+    if use_overlays then [ (import ./overlay.nix) ] ++ overlays else [ ];
 
   nixpkgs = import sources.nixpkgs {
     overlays = used_overlays;
@@ -27,5 +24,4 @@ let
       allowUnfree = true;
     };
   };
-in
-  nixpkgs
+in nixpkgs

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,13 +1,16 @@
 self: super:
 let
   sources = import ./sources.nix;
-  haskellOverlay = import ./haskell-overlay.nix {
-    pkgs = self;
-  };
-in
-{
+  haskellOverlay = import ./haskell-overlay.nix { pkgs = self; };
+  idrisOverlay = import ./idris-overlay.nix { pkgs = self; };
+in {
   sources = if super ? sources then super.sources // sources else sources;
+
   # Generic haskellPackages since neither Idris nor its dependencies
   # are pinned to a specific GHC version.
   haskellPackages = super.haskellPackages.extend haskellOverlay;
+
+  # We can't add dbcritic to the Idris packages overlay because it's not a
+  # proper Idris package
+  dbcritic = self.callPackage ../dbcritic.nix { };
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -19,29 +19,28 @@ let
       pkgs.fetchzip { inherit (spec) url sha256; };
 
   fetch_git = spec:
-    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+    builtins.fetchGit {
+      url = spec.repo;
+      inherit (spec) rev ref;
+    };
 
   fetch_builtin-tarball = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-tarball" will soon be deprecated. You should
-          instead use `builtin = true`.
+    builtins.trace ''
+      WARNING:
+        The niv type "builtin-tarball" will soon be deprecated. You should
+        instead use `builtin = true`.
 
-          $ niv modify <package> -a type=tarball -a builtin=true
-      ''
-      builtins_fetchTarball { inherit (spec) url sha256; };
+        $ niv modify <package> -a type=tarball -a builtin=true
+    '' builtins_fetchTarball { inherit (spec) url sha256; };
 
   fetch_builtin-url = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-url" will soon be deprecated. You should
-          instead use `builtin = true`.
+    builtins.trace ''
+      WARNING:
+        The niv type "builtin-url" will soon be deprecated. You should
+        instead use `builtin = true`.
 
-          $ niv modify <package> -a type=file -a builtin=true
-      ''
-      (builtins_fetchurl { inherit (spec) url sha256; });
+        $ niv modify <package> -a type=file -a builtin=true
+    '' (builtins_fetchurl { inherit (spec) url sha256; });
 
   #
   # Various helpers
@@ -51,84 +50,84 @@ let
   mkPkgs = sources:
     let
       sourcesNixpkgs =
-        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) {};
+        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; })
+        { };
       hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
       hasThisAsNixpkgsPath = <nixpkgs> == ./.;
-    in
-      if builtins.hasAttr "nixpkgs" sources
-      then sourcesNixpkgs
-      else if hasNixpkgsPath && ! hasThisAsNixpkgsPath then
-        import <nixpkgs> {}
-      else
-        abort
-          ''
-            Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
-            add a package called "nixpkgs" to your sources.json.
-          '';
+    in if builtins.hasAttr "nixpkgs" sources then
+      sourcesNixpkgs
+    else if hasNixpkgsPath && !hasThisAsNixpkgsPath then
+      import <nixpkgs> { }
+    else
+      abort ''
+        Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
+        add a package called "nixpkgs" to your sources.json.
+      '';
 
   # The actual fetching function.
   fetch = pkgs: name: spec:
 
-    if ! builtins.hasAttr "type" spec then
+    if !builtins.hasAttr "type" spec then
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
-    else if spec.type == "file" then fetch_file pkgs spec
-    else if spec.type == "tarball" then fetch_tarball pkgs spec
-    else if spec.type == "git" then fetch_git spec
-    else if spec.type == "builtin-tarball" then fetch_builtin-tarball spec
-    else if spec.type == "builtin-url" then fetch_builtin-url spec
+    else if spec.type == "file" then
+      fetch_file pkgs spec
+    else if spec.type == "tarball" then
+      fetch_tarball pkgs spec
+    else if spec.type == "git" then
+      fetch_git spec
+    else if spec.type == "builtin-tarball" then
+      fetch_builtin-tarball spec
+    else if spec.type == "builtin-url" then
+      fetch_builtin-url spec
     else
-      abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+      abort
+      "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
 
   # Ports of functions for older nix versions
 
   # a Nix version of mapAttrs if the built-in doesn't exist
-  mapAttrs = builtins.mapAttrs or (
-    f: set: with builtins;
-    listToAttrs (map (attr: { name = attr; value = f attr set.${attr}; }) (attrNames set))
-  );
+  mapAttrs = builtins.mapAttrs or (f: set:
+    with builtins;
+    listToAttrs (map (attr: {
+      name = attr;
+      value = f attr set.${attr};
+    }) (attrNames set)));
 
   # fetchTarball version that is compatible between all the versions of Nix
   builtins_fetchTarball = { url, sha256 }@attrs:
-    let
-      inherit (builtins) lessThan nixVersion fetchTarball;
-    in
-      if lessThan nixVersion "1.12" then
-        fetchTarball { inherit url; }
-      else
-        fetchTarball attrs;
+    let inherit (builtins) lessThan nixVersion fetchTarball;
+    in if lessThan nixVersion "1.12" then
+      fetchTarball { inherit url; }
+    else
+      fetchTarball attrs;
 
   # fetchurl version that is compatible between all the versions of Nix
   builtins_fetchurl = { url, sha256 }@attrs:
-    let
-      inherit (builtins) lessThan nixVersion fetchurl;
-    in
-      if lessThan nixVersion "1.12" then
-        fetchurl { inherit url; }
-      else
-        fetchurl attrs;
+    let inherit (builtins) lessThan nixVersion fetchurl;
+    in if lessThan nixVersion "1.12" then
+      fetchurl { inherit url; }
+    else
+      fetchurl attrs;
 
   # Create the final "sources" from the config
   mkSources = config:
-    mapAttrs (
-      name: spec:
-        if builtins.hasAttr "outPath" spec
-        then abort
-          "The values in sources.json should not have an 'outPath' attribute"
-        else
-          spec // { outPath = fetch config.pkgs name spec; }
-    ) config.sources;
+    mapAttrs (name: spec:
+      if builtins.hasAttr "outPath" spec then
+        abort
+        "The values in sources.json should not have an 'outPath' attribute"
+      else
+        spec // { outPath = fetch config.pkgs name spec; }) config.sources;
 
   # The "config" used by the fetchers
-  mkConfig =
-    { sourcesFile ? ./sources.json
+  mkConfig = { sourcesFile ? ./sources.json
     , sources ? builtins.fromJSON (builtins.readFile sourcesFile)
-    , pkgs ? mkPkgs sources
-    }: rec {
+    , pkgs ? mkPkgs sources }: rec {
       # The sources, i.e. the attribute set of spec name to spec
       inherit sources;
 
       # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
       inherit pkgs;
     };
-in
-mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }
+in mkSources (mkConfig { }) // {
+  __functor = _: settings: mkSources (mkConfig settings);
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,1 @@
+{ pkgs ? import ./nix/nixpkgs-pinned.nix { } }: pkgs.dbcritic


### PR DESCRIPTION
This adds `dbcritic` to the Nix overlay and sets up a proper shell for `default.nix`. `release.nix` is now used to build dbcritic, which matches our other repos. Dbcritic's Nix overlay can be added to other repos so we can use dbcritic there without requiring any further setup. I initially wanted to do it the proper way with an idris packages overlay for dbcritic, but that requires using `build-idris-package` which only works for proper Idris packages, and dbcritic does not come with an `.ipkg` file so I reverted back to the current method of building.

I also did the honors of running `nixfmt` over everything since we do that everywhere else. Use this diff link for an easier to read diff: https://github.com/channable/dbcritic/compare/9ed11a4dd2aeab91cf4c6eeaf9cc69c7af28a4eb...robbert-vdh/nix-overlay

I did not bother updating the instructions and CI to use more modern Nix tools and conventions. We can do that later if needed.