### PR TITLE
Fix dbcritic build against latest nixpkgs

### DIFF
--- a/dbcritic.nix
+++ b/dbcritic.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, idris, postgresql }:
+{ stdenv, lib, idrisDbcritic, postgresql }:
 stdenv.mkDerivation {
   name = "dbcritic";
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
         && !builtins.elem (baseNameOf path) [ "nix" ".semaphore" ".git" ]);
   };
 
-  buildInputs = [ idris postgresql ];
+  buildInputs = [ idrisDbcritic postgresql ];
 
   phases = [ "unpackPhase" "buildPhase" "installPhase" "fixupPhase" ];
   installPhase = ''

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -2,13 +2,18 @@ self: super:
 let
   sources = import ./sources.nix;
   haskellOverlay = import ./haskell-overlay.nix { pkgs = self; };
-  idrisOverlay = import ./idris-overlay.nix { pkgs = self; };
 in {
   sources = if super ? sources then super.sources // sources else sources;
 
-  # Generic haskellPackages since neither Idris nor its dependencies
-  # are pinned to a specific GHC version.
-  haskellPackages = super.haskellPackages.extend haskellOverlay;
+
+  # Idris does not build on GHC > 9.4
+  haskellPackagesDbcritic = super.haskell.packages.ghc94.extend haskellOverlay;
+  idrisPackagesDbcritic = super.idrisPackages.override {
+    idris-no-deps = self.haskellPackagesDbcritic.idris;
+  };
+  idrisDbcritic = self.idrisPackagesDbcritic.with-packages [
+    self.idrisPackagesDbcritic.base
+  ];
 
   # We can't add dbcritic to the Idris packages overlay because it's not a
   # proper Idris package

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "970a59bd19eff3752ce552935687100c46e820a5",
-        "sha256": "sha256:06binyx1cv10nhw1riana0b5r38754p2qpffaijkax2yx4r3cx09",
+        "rev": "c75037bbf9093a2acb617804ee46320d6d1fea5a",
+        "sha256": "1hs4rfylv0f1sbyhs1hf4f7jsq4np498fbcs5xjlmrkwhx4lpgmc",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/970a59bd19eff3752ce552935687100c46e820a5.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c75037bbf9093a2acb617804ee46320d6d1fea5a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
The build failure was caused by the dependency `dbcritic -> idris -> cheapskate`. Cheapskate is no longer maintained, and no longer compiles on GHC 9.6.

In the latest version of nixpkgs, the default GHC was switched to 9.6. This is how a nixpkgs pin update breaks dbcritic.

The quick solution is to just pin idris and its packages to GHC 9.4. 